### PR TITLE
Adding download badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ computational tools and models to support the design, analysis, optimization,
 scale-up, operation and troubleshooting of innovative, advanced energy systems.
 
 <!-- BEGIN Status badges -->
-## Build statuses
+## Project Build and Download Statuses
 ![Tests](https://github.com/IDAES/idaes-pse/workflows/Tests/badge.svg?branch=main)
 ![Integration](https://github.com/IDAES/idaes-pse/workflows/Integration/badge.svg?branch=main)
 [![codecov](https://codecov.io/gh/IDAES/idaes-pse/branch/main/graph/badge.svg?token=1lNQNbSB29)](https://codecov.io/gh/IDAES/idaes-pse)
@@ -13,6 +13,7 @@ scale-up, operation and troubleshooting of innovative, advanced energy systems.
 [![GitHub contributors](https://img.shields.io/github/contributors/IDAES/idaes-pse.svg)](https://github.com/IDAES/idaes-pse/graphs/contributors)
 [![Merged PRs](https://img.shields.io/github/issues-pr-closed-raw/IDAES/idaes-pse.svg?label=merged+PRs)](https://github.com/IDAES/idaes-pse/pulls?q=is:pr+is:merged)
 [![Issue stats](http://isitmaintained.com/badge/resolution/IDAES/idaes-pse.svg)](http://isitmaintained.com/project/IDAES/idaes-pse)
+[![Downloads](https://pepy.tech/badge/idaes-pse)](https://pepy.tech/project/idaes-pse)
 <!-- END Status badges -->
 
 ## Getting Started


### PR DESCRIPTION
## Fixes

(Stand-alone PR)

## Summary/Motivation:

Badges are the eye-candy of github readme files.

## Changes proposed in this PR:
- Adds a badge from pepy.tech which shows total download and if you click thru even more numbers.
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
